### PR TITLE
Alias method for Rspec protocol compat.

### DIFF
--- a/lib/rspec/json_matcher/abstract_matcher.rb
+++ b/lib/rspec/json_matcher/abstract_matcher.rb
@@ -42,6 +42,7 @@ module RSpec
           inspection("not ")
         end
       end
+      alias :failure_message_when_negated :negative_failure_message
 
       private
 


### PR DESCRIPTION
Hi @r7kamura

A follow up to #3. Adds method name from Rspec 3 protocol as an alias just to prevent noisy deprecation statements.

Notes:
- Pre-Rspec 1.2 failure message protocol was `failure_message` and `negative_failure_message`
- Rspec 2 protocol was `failure_message_for_should` and `failure_message_for_should_not`
- Rspec 3 protocol is `failure_message` and `failure_message_when_negated`
