### PR TITLE
Alias AbstractMatcher#matches? as ===

### DIFF
--- a/lib/rspec/json_matcher/abstract_matcher.rb
+++ b/lib/rspec/json_matcher/abstract_matcher.rb
@@ -22,6 +22,8 @@ module RSpec
         false
       end
 
+      alias_method :===, :matches?
+
       def compare(&reason)
         raise NotImplementedError, "You must implement #{self.class}#compare"
       end

--- a/spec/rspec/json_matcher_spec.rb
+++ b/spec/rspec/json_matcher_spec.rb
@@ -13,6 +13,14 @@ describe RSpec::JsonMatcher do
         {}.to_json.should be_json
       end
     end
+
+    context 'when used with a composable matcher' do
+      it 'matches' do
+        {
+          "a" => {"b" => 1}.to_json
+        }.should match("a" => be_json)
+      end
+    end
   end
 
   describe "#be_json_as" do
@@ -174,6 +182,14 @@ describe RSpec::JsonMatcher do
         { "foo" => "bar" }.to_json.should be_json_as(foo: "bar")
       end
     end
+
+    context 'when used with a composable matcher' do
+      it 'matches' do
+        {
+          "a" => {"b" => 1}.to_json
+        }.should match("a" => be_json_as("b" => 1))
+      end
+    end
   end
 
   describe "#be_json_including" do
@@ -291,6 +307,14 @@ describe RSpec::JsonMatcher do
             nil,
           ],
         )
+      end
+    end
+
+    context 'when used with a composable matcher' do
+      it 'matches' do
+        {
+          "a" => {"b" => 1, "c" => 2}.to_json
+        }.should match("a" => be_json_including("b" => 1))
       end
     end
   end


### PR DESCRIPTION
Defining `===` method on a matcher allows us to use the matcher in
- Composing matchers (rspec >= 3.0)
- Matching method arguments (rspec-mocks)

Use cases:
```rb
# Composing matchers
expect({'data' => {'a' => 1}.to_json}).to match('data' => be_json)
expect([{'a' => 1}.to_json, {'b' => 2}.to_json]).to all(be_json)

# Matching a nested JSON
expect({'a' => {'b' => 1}.to_json}.to_json).to be_json_as('a' => be_json)

# Matching method arguments with rspec-mocks
object = double
expect(object).to receive(:some_method).with(be_json_as('a' => 1))
object.some_method({'a' => 1}.to_json)
```

Users can alias the matchers as, for example, `a_json` if they like a more natual wording:
```rb
RSpec::Matchers.alias_matcher :a_json, :be_json
...
expect(object).to receive(:some_method).with(a_json_as('a' => 1))
```