### PR TITLE
Upgrade to amazing_print gem

### DIFF
--- a/lib/rspec/json_matcher.rb
+++ b/lib/rspec/json_matcher.rb
@@ -6,7 +6,7 @@ require "rspec/json_matcher/abstract_matcher"
 require "rspec/json_matcher/exact_matcher"
 require "rspec/json_matcher/fuzzy_matcher"
 require "json"
-require "awesome_print"
+require "amazing_print"
 
 module RSpec
   module JsonMatcher

--- a/rspec-json_matcher.gemspec
+++ b/rspec-json_matcher.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "json"
-  spec.add_dependency "awesome_print"
+  spec.add_dependency "amazing_print"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The "amazing_print" gem is a great advancement to the less maintained "awesome_print".

The big reason for me is that rails's `ActiveModel::Errors` doesn't respond to `marshal_dump`, resulting in exceptions if I try to print an errors object:
```
[1] pry(main)> Account.first.errors
(pry) output error: #<NoMethodError: undefined method `marshal_dump' for #<ActiveModel::Errors:0x0000000112987f98>
```